### PR TITLE
add T_MATCH to nestingIncrements

### DIFF
--- a/src/CognitiveComplexity/Analyzer.php
+++ b/src/CognitiveComplexity/Analyzer.php
@@ -71,6 +71,7 @@ final class Analyzer
         T_WHILE       => T_WHILE,
         T_DO          => T_DO,
         T_CATCH       => T_CATCH,
+        T_MATCH       => T_MATCH,
     ];
 
     /**

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -58,6 +58,7 @@ final class AnalyzerTest extends TestCase
         yield [__DIR__ . '/Data/function9.php.inc', 5];
         yield [__DIR__ . '/Data/function10.php.inc', 19];
         yield [__DIR__ . '/Data/function11.php.inc', 1];
+        yield [__DIR__ . '/Data/function12.php.inc', 6];
     }
 
     /**

--- a/tests/Data/function12.php.inc
+++ b/tests/Data/function12.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+function matchIncrementsNesting($number) {
+    $a = true;
+    $b = true;
+
+    if ($a) { // +1 if
+        match ($number) { // +1 match +1 nesting
+            1       => $b ? "one" : "uno", // +1 ternary +2 nesting
+            2       => "a couple",
+            3       => "a few",
+            default => "lots",
+        };
+    }
+}
+
+// Cognitive Complexity 6


### PR DESCRIPTION
The `match` construct was not considered originally when the package was written.
The same rules as for `switch` should apply.

Opening a match construct adds 1 complexity (this is already fixed in a previous PR).
However, opening a match construct also should increase nesting level by 1. This is fixed by this PR.